### PR TITLE
feat: 공통 컴포넌트 button component 구현

### DIFF
--- a/src/shared/components/Button/Button.stories.tsx
+++ b/src/shared/components/Button/Button.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 
-import { Button } from './Button';
+import { Button } from '.';
 
 const meta = {
   title: 'Button',
@@ -18,17 +18,22 @@ const meta = {
     },
     variant: {
       control: { type: 'select' },
-      options: ['activate', 'cancel', 'not-activate'],
+      options: ['default', 'active', 'disabled', 'cancel', 'outline'],
       description: '버튼 스타일 색상 (배경, 텍스트 색상, 호버시 색상)',
     },
-    size: {
+    rounded: {
       control: { type: 'select' },
-      options: ['activate', 'sm', 'lg', 'icon'],
-      description: '버튼의 size + border radius',
+      options: ['small', 'medium', 'hard'],
+      description: 'border-radius 입니다.',
+    },
+    height: {
+      control: { type: 'select' },
+      options: ['sm', 'md', 'lg'],
+      description: '버튼의 height',
     },
     children: {
       control: 'text',
-      description: '버튼 텍스트가 올 수도 있고, 이미지가 올 수도 있습니다.',
+      description: '텍스트가 올 수 있수도 있으며 컴포넌트가 올 수 있습니다.',
       defaultValue: 'Button',
     },
     asChild: {
@@ -48,16 +53,34 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    variant: 'activate',
-    size: 'activate',
-    children: '삭제 버튼',
+    variant: 'default',
+    height: 'sm',
+    children: <span className="text-xs">Default</span>,
+  },
+};
+
+export const DisabledButton: Story = {
+  args: {
+    variant: 'disabled',
+    height: 'md',
+    children: <span className="text-xs">Disabled</span>,
   },
 };
 
 export const LargeButton: Story = {
   args: {
-    variant: 'not-activate',
-    size: 'lg',
-    children: '라지 버튼',
+    variant: 'active',
+    height: 'lg',
+    rounded: 'hard',
+    children: <span className="text-md">Large</span>,
+  },
+};
+
+export const CustomButton: Story = {
+  args: {
+    variant: 'default',
+    height: 'md',
+    children: <span className="text-xs">Custom</span>,
+    className: 'bg-turquoise',
   },
 };

--- a/src/shared/components/Button/index.tsx
+++ b/src/shared/components/Button/index.tsx
@@ -9,20 +9,27 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        activate: 'bg-crimsonRed text-white hover:bg-crimsonRed/90',
-        cancel: 'bg-slateGray text-cancel hover:bg-slateGray/90',
-        'not-activate': 'bg-charcoal text-white hover:bg-charcoal/90',
+        default: 'bg-black text-white text-center hover:bg-black/90',
+        active: 'bg-primary text-white text-center hover:bg-primary/90',
+        disabled: 'bg-slateGray text-center hover:bg-slateGray/90',
+        cancel: 'bg-gray text-white text-center hover:bg-gray/90',
+        outline: 'border border-[0.5px] border-gray text-black text-center',
       },
-      size: {
-        activate: 'h-8 px-8 rounded-sm text-[10px]',
-        sm: 'h-6 px-3 rounded-sm',
-        lg: 'w-full h-12 px-8 rounded-md',
-        icon: 'h-9 w-9',
+      rounded: {
+        small: 'rounded-sm',
+        medium: 'rounded-md',
+        hard: 'rounded-lg',
+      },
+      height: {
+        sm: 'h-6 px-3',
+        md: 'h-8 px-4',
+        lg: 'w-full h-12 px-6',
       },
     },
     defaultVariants: {
-      variant: 'activate',
-      size: 'activate',
+      variant: 'default',
+      rounded: 'medium',
+      height: 'md',
     },
   },
 );
@@ -34,11 +41,11 @@ export interface ButtonProps
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, variant, rounded, height, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : 'button';
     return (
       <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
+        className={cn(buttonVariants({ variant, rounded, height, className }))}
         ref={ref}
         {...props}
       />


### PR DESCRIPTION
흔히 사용되어질 것 같은 버튼들 피그마에 만들어두었습니다.
className 으로 커스텀도 가능한 버튼이라 범용적으로 사용할 수 있습니다.

```
<Button variant="default" height="sm">Default Button</Button>

/* 
버튼의 defaultVariants: {
      variant: 'default',
      rounded: 'medium',
      height: 'md',
    },이기 떄문에 아래와 같이 사용하면 위 속성들이 대입된 형태로 나오게 됩니다.
*/
<Button>Button</Button>

```

크로마틱: https://www.chromatic.com/build?appId=675ae27d684b09f88d6a4749&number=4
스토리북 : https://675ae27d684b09f88d6a4749-wkqdrrants.chromatic.com/?path=/story/button--default

<img width="396" alt="스크린샷 2024-12-13 오후 4 24 20" src="https://github.com/user-attachments/assets/238a0c3f-3ffc-4f84-b864-631eb9db7a87" />

