### PR TITLE
feat: breadcrumb component 구현

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
         specifier: ^2.1.4
         version: 2.1.4(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
       '@radix-ui/react-slot':
-        specifier: ^1.1.0
+        specifier: ^1.1.1
         version: 1.1.1(@types/react@18.3.16)(react@19.0.0-rc-66855b96-20241106)
       '@radix-ui/react-tabs':
         specifier: ^1.1.2

--- a/src/shared/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/shared/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Breadcrumb } from '.';
+
+const meta = {
+  title: 'Breadcrumb',
+  component: Breadcrumb,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+  decorators: [(Story) => <Story />],
+  argTypes: {
+    breadList: {
+      control: 'object',
+      description: 'id, text, router로 이루어진 객체를 배열형태로 받습니다.',
+    },
+    pathname: {
+      control: 'text',
+      description:
+        '경로 pathname 통째로 받기 next/navgation 내의 usePathname 경로 그대로 넣어주시면 됩니다.',
+    },
+  },
+} satisfies Meta<typeof Breadcrumb>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    breadList: ['Game', '정규 리그', '경기 일정'],
+    pathname: '/game/regular/schedule',
+  },
+};

--- a/src/shared/components/Breadcrumb/index.tsx
+++ b/src/shared/components/Breadcrumb/index.tsx
@@ -1,0 +1,164 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { ChevronRight, MoreHorizontal } from 'lucide-react';
+
+import { cn } from '@/shared/lib/utils';
+
+const BreadcrumbRoot = React.forwardRef<
+  HTMLElement,
+  React.ComponentPropsWithoutRef<'nav'> & {
+    separator?: React.ReactNode;
+  }
+>(({ ...props }, ref) => (
+  <nav ref={ref} aria-label="breadcrumbRoot" {...props} />
+));
+BreadcrumbRoot.displayName = 'BreadcrumbRoot';
+
+const BreadcrumbList = React.forwardRef<
+  HTMLOListElement,
+  React.ComponentPropsWithoutRef<'ol'>
+>(({ className, ...props }, ref) => (
+  <ol
+    ref={ref}
+    className={cn(
+      'flex flex-wrap items-center gap-1.5 break-words text-sm text-neutral-500 sm:gap-2.5 dark:text-neutral-400',
+      className,
+    )}
+    {...props}
+  />
+));
+BreadcrumbList.displayName = 'BreadcrumbList';
+
+const BreadcrumbItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentPropsWithoutRef<'li'>
+>(({ className, ...props }, ref) => (
+  <li
+    ref={ref}
+    className={cn('inline-flex items-center gap-1.5', className)}
+    {...props}
+  />
+));
+BreadcrumbItem.displayName = 'BreadcrumbItem';
+
+const BreadcrumbLink = React.forwardRef<
+  HTMLAnchorElement,
+  React.ComponentPropsWithoutRef<'a'> & {
+    asChild?: boolean;
+  }
+>(({ asChild, className, ...props }, ref) => {
+  const Comp = asChild ? Slot : 'a';
+
+  return (
+    <Comp
+      ref={ref}
+      className={cn(
+        'transition-colors hover:text-neutral-950 dark:hover:text-neutral-50',
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+BreadcrumbLink.displayName = 'BreadcrumbLink';
+
+const BreadcrumbPage = React.forwardRef<
+  HTMLSpanElement,
+  React.ComponentPropsWithoutRef<'span'>
+>(({ className, ...props }, ref) => (
+  <span
+    ref={ref}
+    role="link"
+    aria-disabled="true"
+    aria-current="page"
+    className={cn(
+      'font-normal text-neutral-950 dark:text-neutral-50',
+      className,
+    )}
+    {...props}
+  />
+));
+BreadcrumbPage.displayName = 'BreadcrumbPage';
+
+const BreadcrumbSeparator = ({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<'li'>) => (
+  <li
+    role="presentation"
+    aria-hidden="true"
+    className={cn('[&>svg]:w-3.5 [&>svg]:h-3.5', className)}
+    {...props}
+  >
+    {children ?? <ChevronRight />}
+  </li>
+);
+BreadcrumbSeparator.displayName = 'BreadcrumbSeparator';
+
+const BreadcrumbEllipsis = ({
+  className,
+  ...props
+}: React.ComponentProps<'span'>) => (
+  <span
+    role="presentation"
+    aria-hidden="true"
+    className={cn('flex h-9 w-9 items-center justify-center', className)}
+    {...props}
+  >
+    <MoreHorizontal className="h-4 w-4" />
+    <span className="sr-only">More</span>
+  </span>
+);
+BreadcrumbEllipsis.displayName = 'BreadcrumbElipssis';
+
+interface BreadcrumbProps {
+  breadList: string[];
+  pathname: string;
+}
+
+const Breadcrumb = ({ breadList, pathname }: BreadcrumbProps) => {
+  const totalLen = breadList.length;
+
+  const pathnameArr = pathname.split('/');
+  pathnameArr.shift();
+
+  let router = '';
+
+  return (
+    <BreadcrumbRoot>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/">Home</BreadcrumbLink>
+          <BreadcrumbSeparator />
+        </BreadcrumbItem>
+
+        {breadList.map((bread, idx) => {
+          const lastItem = idx !== totalLen - 1;
+          router += pathnameArr[idx] + '/';
+
+          return (
+            <>
+              <BreadcrumbItem key={bread}>
+                <BreadcrumbLink
+                  href={router}
+                  className={
+                    lastItem
+                      ? 'text-slateGray hover:text-slateGray/80'
+                      : 'text-primary hover:text-primary/80'
+                  }
+                >
+                  {bread}
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+
+              {lastItem && <BreadcrumbSeparator />}
+            </>
+          );
+        })}
+      </BreadcrumbList>
+    </BreadcrumbRoot>
+  );
+};
+
+export { Breadcrumb };


### PR DESCRIPTION
## ✅ DONE

금일 회의에서 진행했던 아래 컴포넌트 shadcn ui기반으로 breadcrumb 컴포넌트 구현했습니다.

<img width="114" alt="위 컴포넌트 재사용 여부" src="https://github.com/user-attachments/assets/9bfbf1c0-de13-429a-aa07-22cfc1e7e9a1" />

breadList, pathname 두 값을 받게 되는데, breadList에는 출력할 텍스트 넘겨주시면 됩니다.(Home 텍스트는 안넘겨주셔도 됩니다. 모든 페이지에서 맨 앞에 HOME이 와야 한다고 생각하여 breadcrumb component에서 처리했어요 )

pathname에는 next/navigation 내에 usePathname에서 뽑아낸 경로 그대로 보내주시면 됩니다.
예를들어, http://localhost:3000/game/regular/schedule 경로 일때 usePathname으로 얻어낸 경로는 
/game/regular/schedule 입니다.

## Related Links (Optional)

스토리북: https://675ae27d684b09f88d6a4749-rpjrzbvsjh.chromatic.com/?path=/story/breadcrumb--default
