### PR TITLE
feat: 경기일정 페이지 하단 calendar 컴포넌트 구현 완료함 header, content 분리해서 관리

### DIFF
--- a/src/app/game/regular/schedule/page.tsx
+++ b/src/app/game/regular/schedule/page.tsx
@@ -4,10 +4,12 @@ import Banner from '@/shared/components/Banner';
 export default function RegularSchedulePage() {
   return (
     <section>
-      <Banner
-        title="정규 리그"
-        description="kt wiz의 정규리그 결기 일정을 알려 드립니다."
-      />
+      <div className="mt-[100px]">
+        <Banner
+          title="정규 리그"
+          description="kt wiz의 정규리그 결기 일정을 알려 드립니다."
+        />
+      </div>
       <RegularSchedule />
     </section>
   );

--- a/src/components/RegularSchedule/Calendar/BoxCell.tsx
+++ b/src/components/RegularSchedule/Calendar/BoxCell.tsx
@@ -1,0 +1,75 @@
+import {
+  flexColumn,
+  flexColumnCenter,
+  flexRow,
+  flexRowCenter,
+  flexRowSpaceBetween,
+} from '@/styles/flex';
+import OutcomeDisplay from './OutcomeDisplay';
+import Link from 'next/link';
+import Image from 'next/image';
+import { ChevronRight } from 'lucide-react';
+
+interface BoxCellProps {
+  date: number;
+  data: any; // BackEnd Data type 체크 필요
+}
+
+const BoxCell = ({ date, data }: BoxCellProps) => {
+  return (
+    <div
+      className={`w-full ${flexColumn} py-2 px-1 relative h-40 ${
+        date ? 'bg-white' : 'bg-lightGray'
+      } border border-slateGray rounded hover:bg-gray-200`}
+    >
+      <span className="absolute top-2 right-2 text-caption">{date}</span>
+      {data && (
+        <>
+          <div>
+            <Link href="/">
+              <div
+                className={`${flexRowSpaceBetween} items-center px-1 w-[100px] h-8 bg-lightGray rounded-lg`}
+              >
+                <div className={`${flexRow} items-center gap-2`}>
+                  <OutcomeDisplay text="승" />
+                  <span className="text-xs">11 : 5</span>
+                </div>
+
+                <ChevronRight size={12} />
+              </div>
+            </Link>
+          </div>
+          <div className="mt-4">
+            <div className={`${flexRowCenter} gap-1`}>
+              <div className={`${flexColumnCenter}`}>
+                <div className="text-primary">H</div>
+                <Image
+                  src="/logo/ktwiz_logo.png"
+                  alt="team logo"
+                  width={50}
+                  height={37}
+                />
+              </div>
+              <span className="text-primary">VS</span>
+              <div className={`${flexColumnCenter}`}>
+                <div className="text-turquoise">A</div>
+                <Image
+                  src="/logo/lg_logo.png"
+                  alt="team logo"
+                  width={50}
+                  height={37}
+                />
+              </div>
+            </div>
+          </div>
+          <div className={`${flexColumnCenter}`}>
+            <span className="text-primary text-xs">17:00 잠실</span>
+            <span className="text-xs">SPO-T,MS-T,SS-T</span>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default BoxCell;

--- a/src/components/RegularSchedule/Calendar/Content.tsx
+++ b/src/components/RegularSchedule/Calendar/Content.tsx
@@ -1,0 +1,58 @@
+import { flexRowSpaceBetween } from '@/styles/flex';
+import BoxCell from './BoxCell';
+import { useCalendarStore } from '@/store';
+
+const CalendarContent = () => {
+  const { year, month } = useCalendarStore();
+
+  const firstDay = new Date(+year, +month - 1, 1); // 해당 월의 1일
+  const lastDay = new Date(+year, +month, 0); // 다음 달의 0일 (이달의 마지막 날)
+
+  const startDayOfWeek = firstDay.getDay();
+  const totalDays = lastDay.getDate();
+
+  // 날짜 배열 생성: 시작 요일 앞에 빈칸 추가, 이후 날짜 채우기
+  const dates = [
+    ...Array(startDayOfWeek).fill(null), // 빈칸
+    ...Array.from({ length: totalDays }, (_, i) => i + 1), // 1일부터 마지막 날까지
+  ];
+
+  const days = ['일', '월', '화', '수', '목', '금', '토'];
+
+  // 임시 더미데이터 짝수만 데터 담기도록
+  const gameDummyData = Array(31)
+    .fill(null)
+    .map((_, idx) => {
+      const date = idx + 1;
+      return date % 2 === 0 ? { date, game: `Game ${date}` } : null;
+    });
+
+  return (
+    <div className="border-t-[2px] border-black">
+      <header className={`${flexRowSpaceBetween} my-4`}>
+        {days.map((day, idx) => {
+          return (
+            <div
+              className={`w-full ${
+                idx === 0 ? 'text-primary' : 'text-black'
+              } text-center`}
+            >
+              {day}
+            </div>
+          );
+        })}
+      </header>
+      <section className="w-full grid grid-cols-7 gap-2">
+        {dates.map((date, index) => (
+          <BoxCell
+            key={index}
+            date={date}
+            data={gameDummyData[index - 1] ? gameDummyData[index - 1] : null}
+          />
+        ))}
+      </section>
+    </div>
+  );
+};
+
+export default CalendarContent;

--- a/src/components/RegularSchedule/Calendar/Header.tsx
+++ b/src/components/RegularSchedule/Calendar/Header.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { Button } from '@/shared/components';
+import { flexRow, flexRowCenter, flexRowSpaceBetween } from '@/styles/flex';
+import OutcomeDisplay from './OutcomeDisplay';
+import { useState } from 'react';
+import { Select } from '@/shared/components/Select';
+import { useCalendarStore } from '@/store';
+
+const CalendarHeader = () => {
+  const { setYear, setMonth } = useCalendarStore();
+
+  const [isAll, setIsAll] = useState(false);
+
+  const YEARS = [
+    '2024',
+    '2023',
+    '2022',
+    '2021',
+    '2020',
+    '2019',
+    '2018',
+    '2017',
+  ];
+  const MONTHS = [
+    '12',
+    '11',
+    '10',
+    '9',
+    '8',
+    '7',
+    '6',
+    '5',
+    '4',
+    '3',
+    '2',
+    '1',
+  ];
+
+  const toggleAll = () => {
+    setIsAll(() => !isAll);
+  };
+
+  return (
+    <header className={`${flexRowSpaceBetween} items-center`}>
+      <div className={`${flexRow} gap-4`}>
+        <Button
+          variant={`${!isAll ? 'default' : 'outline'}`}
+          onClick={toggleAll}
+        >
+          kt wiz 경기
+        </Button>
+        <Button
+          variant={`${isAll ? 'default' : 'outline'}`}
+          onClick={toggleAll}
+        >
+          전체 경기
+        </Button>
+      </div>
+      <div className={`${flexRowCenter} gap-4`}>
+        <div>
+          <Select
+            defaultText="2024"
+            size="md"
+            onSelect={setYear}
+            itemList={YEARS.map((year) => ({ value: year, text: year }))}
+          />
+        </div>
+        <div>
+          <Select
+            defaultText="12"
+            size="sm"
+            onSelect={setMonth}
+            itemList={MONTHS.map((month) => ({ value: month, text: month }))}
+          />
+        </div>
+      </div>
+      <div className={`${flexRow} gap-2`}>
+        <OutcomeDisplay text="승" />
+        <OutcomeDisplay text="패" />
+        <OutcomeDisplay text="무" />
+      </div>
+    </header>
+  );
+};
+
+export default CalendarHeader;

--- a/src/components/RegularSchedule/Calendar/OutcomeDisplay.tsx
+++ b/src/components/RegularSchedule/Calendar/OutcomeDisplay.tsx
@@ -1,0 +1,21 @@
+import { flexColumnCenter } from '@/styles/flex';
+
+interface OutcomeDisplayProps {
+  text: '승' | '패' | '무';
+}
+
+const OutcomeDisplay = ({ text }: OutcomeDisplayProps) => {
+  let bgColor = '';
+  if (text === '승') bgColor = 'bg-primary';
+  if (text === '패') bgColor = 'bg-nearBlack';
+  if (text === '무') bgColor = 'bg-slateGray';
+  return (
+    <div
+      className={`${flexColumnCenter} w-[24px] h-[24px] ${bgColor} text-xs text-white rounded-md`}
+    >
+      {text}
+    </div>
+  );
+};
+
+export default OutcomeDisplay;

--- a/src/components/RegularSchedule/Calendar/index.tsx
+++ b/src/components/RegularSchedule/Calendar/index.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import CalendarContent from './Content';
+import CalendarHeader from './Header';
+
+const Calendar = () => {
+  return (
+    <section className="w-[980px] m-auto">
+      <CalendarHeader />
+      <div className="mt-4">
+        <CalendarContent />
+      </div>
+    </section>
+  );
+};
+
+export default Calendar;

--- a/src/components/RegularSchedule/index.tsx
+++ b/src/components/RegularSchedule/index.tsx
@@ -1,11 +1,16 @@
+import Calendar from './Calendar';
 import CardScheduleList from './CardScheduleList';
 
 const RegularSchedule = () => {
+  // TODO: (year, month 파라미터로 담아서 useQuery 호출 데이터 받아오기)
   return (
     <div className="container-default">
       <div className="border-t-[2px] border-primary">
         <div className="py-12">
           <CardScheduleList />
+          <div className="mt-24">
+            <Calendar />
+          </div>
         </div>
       </div>
     </div>

--- a/src/store/calendar.ts
+++ b/src/store/calendar.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+
+interface CalendarState {
+  year: string;
+  month: string;
+  setYear: (year: string) => void;
+  setMonth: (month: string) => void;
+}
+
+const today = new Date();
+const currentYear = today.getFullYear().toString();
+const currentMonth = (today.getMonth() + 1).toString().padStart(2, '0');
+
+const useCalendarStore = create<CalendarState>((set) => ({
+  year: currentYear,
+  month: currentMonth,
+  setYear: (year: string) => set({ year }),
+  setMonth: (month: string) => set({ month }),
+}));
+
+export default useCalendarStore;

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -1,1 +1,2 @@
 export { default as useUserStore } from './user';
+export { default as useCalendarStore } from './calendar';


### PR DESCRIPTION
## ✅ DONE

year와 month는 위 스케쥴 컴포넌트에서도 필요하므로 store로 관리했습니다.

## ✅ TODO

- 모바일일때도 어색하지 않게 보여지도록 작업 중입니다.

## 📸 Screenshot (Optional)

<img width="1724" alt="스크린샷 2024-12-19 오후 5 29 51" src="https://github.com/user-attachments/assets/8a37ef6c-94d3-48f7-abd6-1bd68d0fe5d1" />
