### PR TITLE
feat: 박스스코어 페이지 기본적인 레이아웃

### DIFF
--- a/src/app/game/boxscore/page.tsx
+++ b/src/app/game/boxscore/page.tsx
@@ -1,0 +1,14 @@
+import Banner from '@/shared/components/Banner';
+
+export default function BoxScorePage() {
+  return (
+    <section>
+      <div className="mt-[100px]">
+        <Banner
+          title="박스스코어"
+          description="박스스코어 정보를 알려드립니다."
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/app/game/boxscore/page.tsx
+++ b/src/app/game/boxscore/page.tsx
@@ -1,3 +1,4 @@
+import BoxScore from '@/components/BoxScore';
 import Banner from '@/shared/components/Banner';
 
 export default function BoxScorePage() {
@@ -9,6 +10,7 @@ export default function BoxScorePage() {
           description="박스스코어 정보를 알려드립니다."
         />
       </div>
+      <BoxScore />
     </section>
   );
 }

--- a/src/components/BoxScore/BattingStats.tsx
+++ b/src/components/BoxScore/BattingStats.tsx
@@ -1,0 +1,18 @@
+import GameInformationTitle from '../Game/GameInformationTitle';
+
+interface BattingStatsProps {
+  teamName: string;
+}
+
+const BattingStats = ({ teamName }: BattingStatsProps) => {
+  return (
+    <div className="pt-6">
+      <GameInformationTitle titleText={`${teamName} 타자 기록`} />
+      <div className="my-2 h-[300px] border">
+        타자 기록 정보 들어갈 자리(표)
+      </div>
+    </div>
+  );
+};
+
+export default BattingStats;

--- a/src/components/BoxScore/HighLights.tsx
+++ b/src/components/BoxScore/HighLights.tsx
@@ -1,0 +1,12 @@
+import GameInformationTitle from '../Game/GameInformationTitle';
+
+const HighLights = () => {
+  return (
+    <div className="pt-6">
+      <GameInformationTitle titleText="주요 기록" />
+      <div className="my-2 h-[300px] border">주요기록 정보 들어갈 자리</div>
+    </div>
+  );
+};
+
+export default HighLights;

--- a/src/components/BoxScore/PitchingStats.tsx
+++ b/src/components/BoxScore/PitchingStats.tsx
@@ -1,0 +1,18 @@
+import GameInformationTitle from '../Game/GameInformationTitle';
+
+interface PitchingStatsProps {
+  teamName: string;
+}
+
+const PitchingStats = ({ teamName }: PitchingStatsProps) => {
+  return (
+    <div className="pt-6">
+      <GameInformationTitle titleText={`${teamName} 투수 기록`} />
+      <div className="my-2 h-[300px] border">
+        투수 기록 정보 들어갈 자리(표)
+      </div>
+    </div>
+  );
+};
+
+export default PitchingStats;

--- a/src/components/BoxScore/TotalScore.tsx
+++ b/src/components/BoxScore/TotalScore.tsx
@@ -1,0 +1,11 @@
+import { flexColumnCenter } from '@/styles/flex';
+
+const TotalScore = () => {
+  return (
+    <div className={`${flexColumnCenter} h-[250px] border`}>
+      <p>전체 스코어 들어갈 컴포넌트</p>
+    </div>
+  );
+};
+
+export default TotalScore;

--- a/src/components/BoxScore/index.tsx
+++ b/src/components/BoxScore/index.tsx
@@ -1,0 +1,22 @@
+import TotalScore from './TotalScore';
+import HighLights from './HighLights';
+import BattingStats from './BattingStats';
+import PitchingStats from './PitchingStats';
+
+const BoxScore = () => {
+  // BoxScore 구조 => 전체스코어, 주요기록, 타자기록(KT, 상대팀), 투수기록(KT, 상대팀)
+  return (
+    <div className="container-default">
+      <div className="border-t-[2px] border-primary">
+        <TotalScore />
+        <HighLights />
+        <BattingStats teamName="KT" />
+        <BattingStats teamName="상대팀" />
+        <PitchingStats teamName="KT" />
+        <PitchingStats teamName="상대팀" />
+      </div>
+    </div>
+  );
+};
+
+export default BoxScore;

--- a/src/components/Game/GameInformationTitle.tsx
+++ b/src/components/Game/GameInformationTitle.tsx
@@ -1,0 +1,17 @@
+import { flexRow } from '@/styles/flex';
+
+interface GameInformationTitleProps {
+  titleText: string;
+}
+
+// 박스스코어, 순위기록, 관전 포인트에 들어가는 소제목
+const GameInformationTitle = ({ titleText }: GameInformationTitleProps) => {
+  return (
+    <div className={`${flexRow} items-center`}>
+      <div className="bg-[#D60C0C] w-2 h-8 mr-2"></div>
+      <p className="text-lg">{titleText}</p>
+    </div>
+  );
+};
+
+export default GameInformationTitle;


### PR DESCRIPTION
## ✅ DONE
박스스코어 페이지의 기본적인 레이아웃을 잡았습니다. 

<br/>

## ✅ TODO
현재 위치만 잡아두었기 때문에 dumy data로 채워넣는 작업진행 예정입니다.

<br/>

## 📸 Screenshot (Optional)
![image](https://github.com/user-attachments/assets/3bc69e70-d98f-49b9-993a-a60a0499037f)


<br/>

## Related Links (Optional)
