### PR TITLE
feat: 박스스코어 전체 점수와 주요기록 컴포넌트 틀

### DIFF
--- a/src/components/BoxScore/HighLights.tsx
+++ b/src/components/BoxScore/HighLights.tsx
@@ -1,12 +1,53 @@
 import GameInformationTitle from '../Game/GameInformationTitle';
+import { flexRow } from '@/styles/flex';
 
+// 박스스코어 - 주요기록이 들어가는 컴포넌트, DataLine 컴포넌트 부분은 나중에 분리 예정
 const HighLights = () => {
   return (
     <div className="pt-6">
       <GameInformationTitle titleText="주요 기록" />
-      <div className="my-2 h-[300px] border">주요기록 정보 들어갈 자리</div>
+      <div className="my-4 h-[300px]">
+        <Separator />
+        <DataLine
+          dataType="결승타"
+          dataValue="오스틴(1회 1사 1루서 우중간 2루타)"
+        />
+        <Separator />
+        <DataLine dataType="2루타" dataValue="오스틴(1회) 김현수(1회)" />
+        <DataLine dataType="실책" dataValue="오스틴(1회) 김현수(1회)" />
+        <DataLine dataType="도루" dataValue="오스틴(1회) 김현수(1회)" />
+        <DataLine dataType="도루자" dataValue="오스틴(1회) 김현수(1회)" />
+        <DataLine dataType="주루사" dataValue="오스틴(1회) 김현수(1회)" />
+        <DataLine dataType="실책" dataValue="오스틴(1회) 김현수(1회)" />
+        <Separator />
+        <DataLine
+          dataType="심판"
+          dataValue="전일수 이기종 나광남 박종철 문동균 김정국"
+        />
+      </div>
     </div>
   );
 };
 
 export default HighLights;
+
+const Separator = () => {
+  return <div className="w-full h-[1px] bg-[#717781]" />;
+};
+
+interface dataLineType {
+  dataType: string;
+  dataValue: string;
+}
+
+const DataLine = ({ dataType, dataValue }: dataLineType) => {
+  return (
+    <div
+      className={`${flexRow} w-full my-2 ${dataType === '결승타' ? '' : 'text-sm text-[#35383E]'}`}
+    >
+      <div className="w-[14%] text-center">{dataType}</div>
+      <div className="w-[3%]"></div>
+      <div>{dataValue}</div>
+    </div>
+  );
+};

--- a/src/components/BoxScore/TotalScore.tsx
+++ b/src/components/BoxScore/TotalScore.tsx
@@ -1,9 +1,46 @@
-import { flexColumnCenter } from '@/styles/flex';
+import { flexColumnCenter, flexRow, flexRowCenter } from '@/styles/flex';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 
+// 박스스코어 제일 위에 위치한 경기 정보 요약이 들어가는 컴포넌트
 const TotalScore = () => {
   return (
-    <div className={`${flexColumnCenter} h-[250px] border`}>
-      <p>전체 스코어 들어갈 컴포넌트</p>
+    <div className={`${flexRow} h-[250px] bg-[#ECEEF2]/50`}>
+      <div className={`${flexColumnCenter} h-full sm:w-[5%] w-[10%]`}>
+        <ChevronLeft size={50} />
+      </div>
+      <div className={`${flexColumnCenter} h-full sm:w-[90%] w-[80%]`}>
+        {/* 첫번째팀 정보 */}
+        <div className={`${flexRowCenter} h-[55%] w-full`}>
+          <div className={`${flexRowCenter} w-[30%] h-full`}>
+            <div className={`${flexColumnCenter} w-[30%] h-full`}>
+              <p className="text-2xl">KT</p>
+              <p className="text-sm">승 - 김민</p>
+            </div>
+            <div className="w-[30%] text-center">로고</div>
+            <div className="w-[30%] text-center font-bold text-5xl">3</div>
+          </div>
+          {/* 경기장, 경기일자 */}
+          <div
+            className={`${flexColumnCenter} w-[20%] h-full text-center text-sm`}
+          >
+            <p>2024.07.02</p>
+            <p>수원</p>
+          </div>
+          {/* 두번째 팀 정보 */}
+          <div className={`${flexRowCenter} w-[30%] h-full`}>
+            <div className="w-[30%] text-center font-bold text-5xl">2</div>
+            <div className="w-[30%] text-center">로고</div>
+            <div className={`${flexColumnCenter} w-[30%] h-full`}>
+              <p className="text-2xl">LG</p>
+              <p className="text-sm">패 - 최원태</p>
+            </div>
+          </div>
+        </div>
+        <div className="h-[45%] w-full text-center">점수 표가 들어갈 자리</div>
+      </div>
+      <div className={`${flexColumnCenter} h-full sm:w-[5%] w-[10%]`}>
+        <ChevronRight size={50} />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## ✅ DONE
박스스코어 페이지의 제일 위에 들어가는 두가지 컴포넌트의 틀을 잡아놨습니다.

<br/>

## ✅ TODO
- [ ] 더미데이터 이용해서 api들어오면 바로 될 수 있도록 수정하기
- [ ] 표 제작 or shadcn ui 끌어와서 넣어놓기

<br/>

## 📸 Screenshot (Optional)
![image](https://github.com/user-attachments/assets/ced8133b-32a8-43a3-8cd1-3e79245ed2c9)

<br/>

## Related Links (Optional)
