### PR TITLE
refactor/banner

### DIFF
--- a/src/shared/components/Banner/Banner.stories.tsx
+++ b/src/shared/components/Banner/Banner.stories.tsx
@@ -1,8 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import Banner from '.';
-import { useArgs } from '@storybook/preview-api';
-import { Tabs } from '../Tabs';
+import { navData } from '../Header/constants';
 
 const meta = {
   title: 'Banner',
@@ -25,9 +24,10 @@ const meta = {
       control: 'text',
       description: 'bgUrl은 옵셔널 입니다.',
     },
-    navList: {
-      control: false,
-      description: 'navList는 통째로 component 형태로 받습니다.',
+    navData: {
+      control: 'object',
+      description:
+        'navData는 key를 string, value는 객체로 text와 router가 들어갑니다.',
     },
   },
 } satisfies Meta<typeof Banner>;
@@ -54,26 +54,6 @@ export const WithNavList: Story = {
   args: {
     title: 'kt wiz는?',
     description: '한국 프로야구의 ‘10번째 심장’ kt wiz를 소개합니다!',
-  },
-  render: (args) => {
-    const [{ currentTab }, updateArgs] = useArgs();
-    const handleTabChange = (newTab: string) => {
-      updateArgs({ currentTab: newTab });
-    };
-
-    return (
-      <Banner
-        title="kt wiz는?"
-        description="한국 프로야구의 ‘10번째 심장’ kt wiz를 소개합니다!"
-        navList={
-          <Tabs
-            {...args}
-            currentTab={currentTab}
-            onTabChange={handleTabChange}
-            tabsData={['구단 소개', '구단 연혁']}
-          />
-        }
-      />
-    );
+    navData: navData['player'].items,
   },
 };

--- a/src/shared/components/Banner/index.tsx
+++ b/src/shared/components/Banner/index.tsx
@@ -1,18 +1,35 @@
+'use client';
+
 import { flexColumn, flexColumnCenter } from '@/styles/flex';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Tabs } from '../Tabs';
 
 interface BannerProps {
   title: string;
   description: string;
   bgUrl?: string;
-  navList?: React.ReactNode;
+  navData?: { id: string; text: string; router?: string }[];
 }
 
 const Banner = ({
   title,
   description,
   bgUrl = '/common/banner.png',
-  navList,
+  navData,
 }: BannerProps) => {
+  const router = useRouter();
+
+  const [currentTab, setCurrentTab] = useState(navData ? navData[0].text : '');
+
+  const handleGoRouter = (selectText: string) => {
+    setCurrentTab(selectText);
+    const goRouter = navData?.find((nav) => nav.text === selectText)
+      ?.router as string;
+
+    router.push(goRouter);
+  };
+
   return (
     <div
       className={`${flexColumnCenter} w-screen h-[254px] relative text-center bg-cover bg-[position:60%]`}
@@ -24,9 +41,13 @@ const Banner = ({
         <h1 className="text-title text-white">{title}</h1>
         <span className="text-charcoal text-sm">{description}</span>
       </div>
-      {navList && (
+      {navData && (
         <div className="absolute bottom-0 left-1/2 -translate-x-1/2">
-          {navList}
+          <Tabs
+            currentTab={currentTab}
+            onTabChange={handleGoRouter}
+            tabsData={navData.map((nav) => nav.text)}
+          />
         </div>
       )}
     </div>

--- a/src/shared/components/Header/constants.ts
+++ b/src/shared/components/Header/constants.ts
@@ -1,6 +1,5 @@
-export const navData = [
-  {
-    id: 'ktwiz',
+export const navData = {
+  ktwiz: {
     text: 'kt wiz',
     router: '/',
     items: [
@@ -11,8 +10,7 @@ export const navData = [
       { id: 'wallpaper', text: '월페이퍼', router: '/wallpaper' },
     ],
   },
-  {
-    id: 'wizpark',
+  wizpark: {
     text: 'wiz park',
     router: '/wiz',
     items: [
@@ -22,8 +20,7 @@ export const navData = [
       { id: 'iksan', text: '익산야구장', router: '/wiz/iksan' },
     ],
   },
-  {
-    id: 'game',
+  game: {
     text: 'Game',
     router: '/game',
     items: [
@@ -33,21 +30,19 @@ export const navData = [
       { id: 'point', text: '관전포인트', router: '/game/point' },
     ],
   },
-  {
-    id: 'player',
+  player: {
     text: 'Player',
     router: '/player',
     items: [
-      { id: 'coach', text: '코칭스텝', router: '/player/coach' },
-      { id: 'bowler', text: '투수', router: '/player/bowler' },
+      { id: 'coach', text: '코칭스텝', router: '/player/coachstep' },
+      { id: 'bowler', text: '투수', router: '/player/pitcher' },
       { id: 'batter', text: '타자', router: '/player/batter' },
-      { id: 'chher_squad', text: '응원단', router: '/player/cheer_squad' },
-      { id: 'chher_song', text: '응원가', router: '/player/cheer_song' },
+      { id: 'chher_squad', text: '응원단', router: '/player/cheersquad' },
+      { id: 'chher_song', text: '응원가', router: '/player/cheersong' },
       { id: 'copyright', text: '응원가 저작권', router: '/player/copyright' },
     ],
   },
-  {
-    id: 'media',
+  media: {
     text: 'Media',
     router: '/media',
     items: [
@@ -57,7 +52,7 @@ export const navData = [
       { id: 'wiz_photo', text: 'wiz 포토', router: '/media/photo' },
     ],
   },
-];
+};
 
 export const homeCss = {
   header: 'bg-transparent hover:text-black',

--- a/src/shared/components/Header/index.tsx
+++ b/src/shared/components/Header/index.tsx
@@ -52,10 +52,10 @@ const Header = () => {
         </Link>
         <nav className="w-full">
           <ul className={`${flexRow} justify-between`}>
-            {navData.map((nav) => {
+            {Object.entries(navData).map(([key, nav]) => {
               return (
                 <li
-                  id={nav.id}
+                  id={key}
                   className={`${
                     isHover ? hoverCss['nav'] : currentCss['nav']
                   } w-[90px] text-center font-bold transition-colors duration-300`}
@@ -97,10 +97,10 @@ const Header = () => {
       </div>
       {isHover && (
         <div className={`w-[910px] ${flexRow} m-auto`}>
-          {navData.map((nav) => {
+          {Object.entries(navData).map(([key, nav]) => {
             return (
               <ul
-                key={nav.id}
+                key={key}
                 className={`${flexColumn} gap-2 w-[158px] py-4 text-center border-l-[1px] border-lightGray`}
               >
                 {nav.items.map((item) => {

--- a/src/shared/components/Tabs/Tabs.stories.tsx
+++ b/src/shared/components/Tabs/Tabs.stories.tsx
@@ -36,14 +36,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     currentTab: '구단 소개',
-    tabsData: {
-      coachstep: { text: '코칭 스텝', router: '/player/coachstep' },
-      pitcher: { text: '투수', router: '/player/pitcher' },
-      batter: { text: '타자', router: 'player/batter' },
-      chhersquad: { text: '응원단', router: 'player/cheersquad' },
-      cheersong: { text: '응원가', router: 'player/cheersong' },
-      copyright: { text: '응원가 저작권', router: 'player/copyright' },
-    },
+    tabsData: ['구단 소개', '구단 연혁'],
     onTabChange: fn(),
   },
   render: (args) => {

--- a/src/shared/components/Tabs/index.tsx
+++ b/src/shared/components/Tabs/index.tsx
@@ -3,14 +3,9 @@ import * as TabsPrimitive from '@radix-ui/react-tabs';
 
 import { cn } from '@/shared/lib/utils';
 
-interface TabData {
-  text: string;
-  router?: string;
-}
-
-interface TabsProps<T extends TabData> {
+interface TabsProps {
   currentTab: string;
-  tabsData: Record<string, T>;
+  tabsData: string[];
   onTabChange: (newTab: string) => void;
 }
 
@@ -67,21 +62,13 @@ const TabsContent = React.forwardRef<
 ));
 TabsContent.displayName = TabsPrimitive.Content.displayName;
 
-const Tabs = <T extends TabData>({
-  currentTab,
-  tabsData,
-  onTabChange,
-}: TabsProps<T>) => {
+const Tabs = ({ currentTab, tabsData, onTabChange }: TabsProps) => {
   return (
     <TabsRoot value={currentTab} onValueChange={onTabChange}>
       <TabsList>
-        {Object.entries(tabsData).map(([tabKey, tabData]) => (
-          <TabsTrigger
-            key={tabKey}
-            value={tabData.text}
-            isActive={currentTab === tabData.text}
-          >
-            {tabData.text}
+        {tabsData.map((tab) => (
+          <TabsTrigger key={tab} value={tab} isActive={currentTab === tab}>
+            {tab}
           </TabsTrigger>
         ))}
       </TabsList>


### PR DESCRIPTION
## ✅ DONE

금일 회의때 얘기나온대로 Banner 내 코드 navList를 element로 받는 대신, 데이터 객체를 받아 banner 내부 컴포넌트에서 tab을 핸들링할 수 있게 수정했습니다.

그리하여~~  아래 페이지 컴포넌트를 서버컴포넌트로 관리할 수 있게 되었습니다.
navData는 상수로 관리중이며, Header Component에서도 navData를 같이 사용중입니다.

```
'use server'

import Player from '@/components/Player';
import Banner from '@/shared/components/Banner';
import { navData } from '@/shared/components/Header/constants';

export default function CoachStep() {
  return (
    <section>
      <div className="mt-[100px]">
        <Banner
          title="코칭스텝"
          description="최고의 kt wiz 코칭스텝을 소개합니다."
          navData={navData['player'].items}
        />
      </div>
      <Player />
    </section>
  );
}
```