### PR TITLE
fix: 관전포인트 페이지 로고 수정

### DIFF
--- a/src/components/Point/LineUp.tsx
+++ b/src/components/Point/LineUp.tsx
@@ -5,10 +5,12 @@ import { player } from '@/interface/point';
 
 interface propsType {
   homeInfo: {
+    teamCode: string;
     teamName: string;
     teamLogo: string;
   };
   visitInfo: {
+    teamCode: string;
     teamName: string;
     teamLogo: string;
   };

--- a/src/components/Point/LineUpImage.tsx
+++ b/src/components/Point/LineUpImage.tsx
@@ -3,6 +3,7 @@ import { player } from '@/interface/point';
 
 interface propsType {
   teamInfo: {
+    teamCode: string;
     teamName: string;
     teamLogo: string;
   };
@@ -13,7 +14,11 @@ const LineUpImage = ({ teamInfo, lineupInfo }: propsType) => {
   return (
     <div className={`${flexColumnCenter} w-full`}>
       <div className={`${flexRowCenter} pr-4`}>
-        <img src={teamInfo.teamLogo} alt="logo" className="w-20 h-20" />
+        <img
+          src={`/images/logo/${teamInfo.teamCode}.png`}
+          alt="logo"
+          className="w-20 h-20"
+        />
         <p className="text-xl">{teamInfo.teamName} 라인업</p>
       </div>
       <div className="relative">

--- a/src/components/Point/index.tsx
+++ b/src/components/Point/index.tsx
@@ -38,10 +38,12 @@ const Point = ({ pointData, setGameData }: propsType) => {
         />
         <LineUp
           homeInfo={{
+            teamCode: pointData.gameScore.homeKey,
             teamName: pointData.gameScore.home,
             teamLogo: pointData.gameScore.homeLogo,
           }}
           visitInfo={{
+            teamCode: pointData.gameScore.visitKey,
             teamName: pointData.gameScore.visit,
             teamLogo: pointData.gameScore.visitLogo,
           }}


### PR DESCRIPTION
## ✅ DONE
- 관전 포인트 페이지에서 로고 로딩 안되는것 수정을 위한 방식 변경

<br/>

## ✅ TODO

<br/>

## 📸 Screenshot (Optional)

| 기능 | 스크린샷 |
| ---- | -------- |
|      |          |

<br/>

## Related Links (Optional)
